### PR TITLE
Remove var-args from API

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,16 +1,9 @@
 'use strict';
 
-var apply = require('fast-apply');
-
 module.exports = function read(res, options, cb) {
-
-	var _args = arguments;
-	var argsLength = 3;
-
 	if (typeof options === 'function') {
 		cb = options;
 		options = {};
-		argsLength --;
 	}
 
 	if (typeof options === 'string' || options === undefined || options === null) {
@@ -40,12 +33,6 @@ module.exports = function read(res, options, cb) {
 			data = data.toString(options.encoding || 'utf-8');
 		}
 
-		var args = [err, data];
-
-		for (var i = argsLength; i < _args.length; i++) {
-			args.push(_args[i]);
-		}
-
-		apply(cb, null, args);
+		cb(err, data);
 	});
 };

--- a/readme.md
+++ b/readme.md
@@ -14,10 +14,10 @@ $ npm install --save read-all-stream
 var read = require('read-all-stream');
 var stream = fs.createReadStream('index.js');
 
-read(stream, 'utf-8', function (err, data, message) {
-	console.log(message + data.length);
-	//=> Hello, your data length: 42
-}, 'Hello, your data length: ');
+read(stream, 'utf-8', function (err, data) {
+	console.log(data.length);
+	//=> 42
+});
 
 ```
 
@@ -46,7 +46,7 @@ Default: `'utf8'`
 
 Encoding to be used on `toString` of the data. If null, the body is returned as a Buffer.
 
-##### callback(err, data, args...)
+##### callback(err, data)
 
 ###### err
 
@@ -55,10 +55,6 @@ Encoding to be used on `toString` of the data. If null, the body is returned as 
 ###### data
 
 The data in stream.
-
-##### args...
-
-These arguments will be passed to callback.
 
 ## License
 

--- a/test.js
+++ b/test.js
@@ -49,16 +49,6 @@ it('should read data to string', function (done) {
 	});
 });
 
-it('should add arguments to callback', function (done) {
-	var stream = new Readable();
-	stream.push(null);
-
-	read(stream, 'utf-8', function (err, data, message) {
-		assert(/bingo/.test(message));
-		done();
-	}, 'bingo');
-});
-
 it('should work with undefined encoding', function (done) {
 	var stream = new Readable();
 	stream.push('woo ');


### PR DESCRIPTION
This should be handled on userland. Plain apply is kind-of slow, fast-apply is hacky.

---

This will lead to this code in got:

```diff
diff --git a/index.js b/index.js
index 4154ce3..3e31d13 100644
--- a/index.js
+++ b/index.js
@@ -95,7 +95,9 @@ function got(url, opts, cb) {
                                return;
                        }

-                       read(res, encoding, cb, response);
+                       read(res, encoding, function (err, data) {
+                                cb.call(null, err, data, response);
+                       });
                }).once('error', cb);

                if (opts.timeout) {
```

But I think it is better, than what we have now.

//cc @sindresorhus