### PR TITLE
handle when 'data' event returns string

### DIFF
--- a/index.js
+++ b/index.js
@@ -23,6 +23,9 @@ module.exports = function read(stream, options, cb) {
 	var err = null;
 
 	stream.on('data', function (chunk) {
+		if (!Buffer.isBuffer(chunk)) {
+			chunk = new Buffer(chunk)
+		}
 		chunks.push(chunk);
 		len += chunk.length;
 	});


### PR DESCRIPTION
a string is expected as per https://iojs.org/api/stream.html#stream_event_data.

necessary because `Buffer.concat()` expects a list of `Buffers` as per https://iojs.org/api/buffer.html#buffer_class_method_buffer_concat_list_totallength.