### PR TITLE
Tweak readme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -4,7 +4,7 @@
 
 ## Install
 
-```sh
+```
 $ npm install --save read-all-stream
 ```
 
@@ -69,4 +69,4 @@ The data in stream.
 MIT © [Vsevolod Strukchinsky](floatdrop@gmail.com)
 
 [travis-url]: https://travis-ci.org/floatdrop/read-all-stream
-[travis-image]: http://img.shields.io/travis/floatdrop/read-all-stream.svg?style=flat
+[travis-image]: https://img.shields.io/travis/floatdrop/read-all-stream.svg


### PR DESCRIPTION
* do not use unsophisticated `sh` syntax highlight
  * You can see `read` is unexpectedly colored with cyan.
* fetch the Travis badge via HTTP*S*
  * [Web Security: Why You Should Always Use HTTPS](http://mashable.com/2011/05/31/https-web-security/)
* remove unnecessary `style` parameter from the badge URL
  * [shields.io](http://shields.io/) now provides badges in a flat style by default.
