### PR TITLE
Bump pinkie-promise to 2.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "mocha": "*"
   },
   "dependencies": {
-    "pinkie-promise": "^1.0.0",
+    "pinkie-promise": "^2.0.0",
     "readable-stream": "^2.0.0"
   }
 }


### PR DESCRIPTION
This is purely for selfish reasons to reduce the number of dependencies for downstream libraries like `got@5.4.1`, when compatibility with older Node versions is required.

Without this change, installing `got@5.x-branch` ends up with two versions of `pinkie-promise` (and `pinkie`) in node_modules, 2.x from `got` and 1.x from `read-all-stream`:

```
$ npm install --save got@5.x-branch
my-module@0.1.0 /Users/nexdrew/git/my-module
└─┬ got@5.4.1 
  ├─┬ create-error-class@2.0.1 
  │ ├── capture-stack-trace@1.0.0 
  │ └── inherits@2.0.1 
  ├── duplexer2@0.1.4 
  ├── is-plain-obj@1.1.0 
  ├── is-redirect@1.0.0 
  ├── is-retry-allowed@1.0.0 
  ├── is-stream@1.0.1 
  ├── lowercase-keys@1.0.0 
  ├── node-status-codes@1.0.0 
  ├── object-assign@4.0.1 
  ├─┬ parse-json@2.2.0 
  │ └─┬ error-ex@1.3.0 
  │   └── is-arrayish@0.2.1 
  ├─┬ pinkie-promise@2.0.0 <---
  │ └── pinkie@2.0.1 
  ├─┬ read-all-stream@3.0.1 
  │ └─┬ pinkie-promise@1.0.0 <---
  │   └── pinkie@1.0.0 
  ├─┬ readable-stream@2.0.5 
  │ ├── core-util-is@1.0.2 
  │ ├── isarray@0.0.1 
  │ ├── process-nextick-args@1.0.6 
  │ ├── string_decoder@0.10.31 
  │ └── util-deprecate@1.0.2 
  ├── timed-out@2.0.0 
  ├── unzip-response@1.0.0 
  └─┬ url-parse-lax@1.0.0 
    └── prepend-http@1.0.3 

$ find node_modules -name pinkie-promise
node_modules/pinkie-promise
node_modules/read-all-stream/node_modules/pinkie-promise
```

Would be nice to remove the need for the 1.x versions.
